### PR TITLE
Add new protocols, fix renamed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -87,6 +87,7 @@ xt_ndpi-y := main.o \
                 ${NDPI_PRO}/twitter.o \
                 ${NDPI_PRO}/qq.o \
                 ${NDPI_PRO}/quake.o \
+								${NDPI_PRO}/quic.o \
                 ${NDPI_PRO}/radius.o \
                 ${NDPI_PRO}/rdp.o \
                 ${NDPI_PRO}/rtp.o \
@@ -103,6 +104,8 @@ xt_ndpi-y := main.o \
                 ${NDPI_PRO}/smb.o \
                 ${NDPI_PRO}/snmp.o \
                 ${NDPI_PRO}/socrates.o \
+								${NDPI_PRO}/socks4.o \
+								${NDPI_PRO}/socks5.o \
                 ${NDPI_PRO}/sopcast.o \
                 ${NDPI_PRO}/soulseek.o \
                 ${NDPI_PRO}/spotify.o \
@@ -137,7 +140,7 @@ xt_ndpi-y := main.o \
                 ${NDPI_PRO}/xdmcp.o \
                 ${NDPI_PRO}/yahoo.o \
                 ${NDPI_PRO}/megaco.o \
-                ${NDPI_PRO}/redis.o \
+                ${NDPI_PRO}/redis_net.o \
                 ${NDPI_PRO}/vhua.o \
                 ${NDPI_PRO}/ayiya.o \
                 ${NDPI_PRO}/zattoo.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,7 @@ xt_ndpi-y := main.o \
                 ${NDPI_PRO}/sflow.o \
                 ${NDPI_PRO}/shoutcast.o \
                 ${NDPI_PRO}/sip.o \
-                ${NDPI_PRO}/zmq.o \
+                ${NDPI_PRO}/zeromq.o \
                 ${NDPI_PRO}/skinny.o \
                 ${NDPI_PRO}/skype.o \
                 ${NDPI_PRO}/smb.o \

--- a/src/xt_ndpi.h
+++ b/src/xt_ndpi.h
@@ -1,20 +1,20 @@
-/* 
+/*
  * xt_ndpi.h
  * Copyright (C) 2010-2012 G. Elian Gidoni <geg@gnu.org>
  *               2012 Ed Wildgoose <lists@wildgooses.com>
- * 
+ *
  * This file is part of nDPI, an open source deep packet inspection
  * library based on the PACE technology by ipoque GmbH
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -48,7 +48,7 @@ struct xt_ndpi_mtinfo {
 "APPLE_ITUNES","RADIUS","WINDOWS_UPDATE","TEAMVIEWER","TUENTI","LOTUS_NOTES","SAP","GTP","UPNP","LLMNR","REMOTE_SCAN","SPOTIFY",\
 "WEBM","H323","OPENVPN","NOE","CISCOVPN","TEAMSPEAK","TOR","SKINNY","RTCP","RSYNC","ORACLE","CORBA","UBUNTUONE","WHOIS_DAS",\
 "COLLECTD","SOCKS5","SOCKS4","RTMP","FTP_DATA","WIKIPEDIA","ZMQ","AMAZON","EBAY","CNN","MEGACO","REDIS","PANDO","VHUA","TELEGRAM",\
-"FACEBOOK_CHAT","PANDORA","Vevo"
+"FACEBOOK_CHAT","PANDORA","Vevo","QUIC"
 #endif
 
 #ifndef NDPI_PROTOCOL_SHORT_STRING
@@ -68,7 +68,7 @@ struct xt_ndpi_mtinfo {
 "apple_itunes","radius","windows_update","teamviewer","tuenti","lotusnotes","sap","gtp","upnp","llmnr","remotescan","spotify",\
 "webm","h323","openvpn","noe","ciscovpn","teamspeak","tor","skinny","rtcp","rsync","oracle","corba","ubuntuone","whois_das",\
 "collectd","socks5","socks4","rtmp","ftpdata","wikipedia","zmq","amazon","ebay","cnn","megaco","redis","pando","vhua","telegram",\
-"facebook_chat","pandora","vevo"
+"facebook_chat","pandora","vevo","quic"
 #endif
 
 #ifndef NDPI_LAST_NFPROTO


### PR DESCRIPTION
Added SOCKS4, SOCKS5, and quic to Makefile. Renamed zmq->zeromq and redis->redis_net, also in Makefile.
The module seems to compile and work fine even without the patches as of commit 12f89ff from ntop/nDPI.git
